### PR TITLE
Store entity_id in window.localStorage for page reload

### DIFF
--- a/src/dialogs/lcn-create-entity-dialog.ts
+++ b/src/dialogs/lcn-create-entity-dialog.ts
@@ -89,7 +89,6 @@ export class CreateEntityDialog extends LitElement {
             `,
           )}
         </ha-select>
-
         <ha-textfield
           id="name-input"
           label=${this.lcn.localize("entity-id")}

--- a/src/lcn-router.ts
+++ b/src/lcn-router.ts
@@ -1,8 +1,7 @@
-import { customElement, property, state } from "lit/decorators";
+import { customElement, property } from "lit/decorators";
 import { HassRouterPage, RouterOptions } from "@ha/layouts/hass-router-page";
 import type { HomeAssistant, Route } from "@ha/types";
 import { LCNLogger } from "lcn-logger";
-import { getConfigEntry } from "@ha/data/config_entries";
 import { LCN } from "./types/lcn";
 
 const logger = new LCNLogger("router");
@@ -16,8 +15,6 @@ class LCNRouter extends HassRouterPage {
   @property({ attribute: false }) public route!: Route;
 
   @property({ type: Boolean }) public narrow!: boolean;
-
-  @state() private _searchParms = new URLSearchParams(window.location.search);
 
   protected routerOptions: RouterOptions = {
     defaultPage: "devices",
@@ -38,7 +35,7 @@ class LCNRouter extends HassRouterPage {
         },
       },
     },
-    initialLoad: () => this._fetchConfigEntry(this._searchParms.get("config_entry")!),
+    // initialLoad: () => this._initialLoad(),
   };
 
   protected updatePageEl(el): void {
@@ -49,10 +46,8 @@ class LCNRouter extends HassRouterPage {
     logger.debug(`Current Page: ${this._currentPage} Route: ${this.route.path}`);
   }
 
-  private async _fetchConfigEntry(entry_id: string) {
-    const res = await getConfigEntry(this.hass!, entry_id);
-    this.lcn.config_entry = res.config_entry;
-  }
+  // private async _initialLoad() {
+  // }
 }
 
 declare global {


### PR DESCRIPTION
The entity_id is stored/retrieved in/from the window.localStorage so the dashboard of the frontend survives a page reload.