### PR TITLE
Fix dialog selections

### DIFF
--- a/src/dialogs/lcn-config-binary-sensor.ts
+++ b/src/dialogs/lcn-config-binary-sensor.ts
@@ -171,6 +171,7 @@ export class LCNConfigBinarySensorElement extends LitElement {
 
     this._sourceType = this._sourceTypes.find((sourceType) => sourceType.id === target.value)!;
     this._source = this._sourceType.value[0];
+    this.domainData.source = this._source.value;
   }
 
   private _sourceChanged(ev: CustomEvent): void {

--- a/src/dialogs/lcn-config-light.ts
+++ b/src/dialogs/lcn-config-light.ts
@@ -192,6 +192,7 @@ export class LCNConfigLightElement extends LitElement {
 
     this._portType = this._portTypes.find((portType) => portType.id === target.value)!;
     this._port = this._portType.value[0];
+    this.domainData.output = this._port.value;
   }
 
   private _portChanged(ev: ValueChangedEvent<string>): void {

--- a/src/dialogs/lcn-config-sensor.ts
+++ b/src/dialogs/lcn-config-sensor.ts
@@ -261,6 +261,7 @@ export class LCNConfigSensorElement extends LitElement {
 
     this._sourceType = this._sourceTypes.find((sourceType) => sourceType.id === target.value)!;
     this._source = this._sourceType.value[0];
+    this.domainData.source = this._source.value;
   }
 
   private _sourceChanged(ev: CustomEvent): void {

--- a/src/dialogs/lcn-config-switch.ts
+++ b/src/dialogs/lcn-config-switch.ts
@@ -191,6 +191,7 @@ export class LCNConfigSwitchElement extends LitElement {
 
     this._portType = this._portTypes.find((portType) => portType.id === target.value)!;
     this._port = this._portType.value[0];
+    this.domainData.output = this._port.value;
   }
 
   private _portChanged(ev: ValueChangedEvent<string>): void {


### PR DESCRIPTION
Switching to `ha-md-select` introduced a bug as changing the values of a `ha-md-select` does not automatically trigger the `changed` method.
Fix dialog selections if type for binsensor, light, sensor or switch changed.